### PR TITLE
mark delayedBy extension as renamed

### DIFF
--- a/Eventual/Eventual.swift
+++ b/Eventual/Eventual.swift
@@ -91,6 +91,11 @@ extension Eventual {
             return r.eventual.map { _ in t }
         }
     }
+
+    @available(*, unavailable, renamed: "delayed(by:)")
+    public func delayedBy(_ seconds: Double) -> Eventual<T> {
+        return delayed(by: seconds)
+    }
 }
 
 // MARK: - Resolver

--- a/Eventual/Eventual.swift
+++ b/Eventual/Eventual.swift
@@ -144,6 +144,28 @@ extension Eventually {
     }
 }
 
+// MARK: renamed Swift 2.3 'join' functions
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B>(_ e1: Eventual<A>, _ e2: Eventual<B>) -> Eventual<(A, B)> {
+    return e1.flatMap { a in e2.map { b in (a,b) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>) -> Eventual<(A, B, C)> {
+    return Eventually.join(e1, e2).flatMap { (a: A, b: B) in e3.map { c in (a, b, c) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>) -> Eventual<(A, B, C, D)> {
+    return Eventually.join(e1, e2, e3).flatMap { (a: A, b: B, c: C) in e4.map { d in (a, b, c, d) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D, E>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>, _ e5: Eventual<E>) -> Eventual<(A, B, C, D, E)> {
+    return Eventually.join(e1, e2, e3, e4).flatMap { (a: A, b: B, c: C, d: D) in e5.map { e in (a, b, c, d, e) } }
+}
+
+
 // MARK: lift
 
 extension Eventually {
@@ -164,6 +186,22 @@ extension Eventually {
             join(eA, eB, eC).map(f)
         }
     }
+}
+
+// MARK: renamed Swift 2.3 'lift' functions
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B>(_ f: @escaping (A) -> B) -> ((Eventual<A>) -> Eventual<B>) {
+    return { (eA: Eventual<A>) in eA.map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C>(_ f: @escaping (A, B) -> C) -> ((Eventual<A>, Eventual<B>) -> Eventual<C>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>) in Eventually.join(eA, eB).map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C,D>(_ f: @escaping (A, B, C) -> D) -> ((Eventual<A>, Eventual<B>, Eventual<C>) -> Eventual<D>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>, eC: Eventual<C>) in Eventually.join(eA, eB, eC).map(f) }
 }
 
 // MARK: operators


### PR DESCRIPTION
Retaining delayedBy(seconds:) and annotating it as unavailable will make migration easier.

Implementation will act as convenience method if someone deletes the annotation.
