### PR TITLE
Swift 3: annotate renamed functions/method

### DIFF
--- a/Eventual.xcodeproj/project.pbxproj
+++ b/Eventual.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AEA8BF181C6A661D00DD0C90 /* Eventual.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEA8BF0D1C6A661D00DD0C90 /* Eventual.framework */; };
 		AEA8BF1D1C6A661D00DD0C90 /* EventualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8BF1C1C6A661D00DD0C90 /* EventualTests.swift */; };
 		AEA8BF281C6A663F00DD0C90 /* Eventual.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8BF271C6A663F00DD0C90 /* Eventual.swift */; };
+		D91276DF1DC55D9900117702 /* RenamedForSwift3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91276DE1DC55D9900117702 /* RenamedForSwift3.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +33,7 @@
 		AEA8BF1E1C6A661D00DD0C90 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AEA8BF271C6A663F00DD0C90 /* Eventual.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Eventual.swift; sourceTree = "<group>"; };
 		AEA8BF791C6E8D9C00DD0C90 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
+		D91276DE1DC55D9900117702 /* RenamedForSwift3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenamedForSwift3.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +80,7 @@
 				AEA8BF101C6A661D00DD0C90 /* Eventual.h */,
 				AEA8BF121C6A661D00DD0C90 /* Info.plist */,
 				AEA8BF271C6A663F00DD0C90 /* Eventual.swift */,
+				D91276DE1DC55D9900117702 /* RenamedForSwift3.swift */,
 			);
 			path = Eventual;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D91276DF1DC55D9900117702 /* RenamedForSwift3.swift in Sources */,
 				AEA8BF281C6A663F00DD0C90 /* Eventual.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Eventual/Eventual.swift
+++ b/Eventual/Eventual.swift
@@ -91,11 +91,6 @@ extension Eventual {
             return r.eventual.map { _ in t }
         }
     }
-
-    @available(*, unavailable, renamed: "delayed(by:)")
-    public func delayedBy(_ seconds: Double) -> Eventual<T> {
-        return delayed(by: seconds)
-    }
 }
 
 // MARK: - Resolver
@@ -144,28 +139,6 @@ extension Eventually {
     }
 }
 
-// MARK: renamed Swift 2.3 'join' functions
-@available(*, unavailable, renamed: "Eventually.join")
-public func join<A, B>(_ e1: Eventual<A>, _ e2: Eventual<B>) -> Eventual<(A, B)> {
-    return e1.flatMap { a in e2.map { b in (a,b) } }
-}
-
-@available(*, unavailable, renamed: "Eventually.join")
-public func join<A, B, C>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>) -> Eventual<(A, B, C)> {
-    return Eventually.join(e1, e2).flatMap { (a: A, b: B) in e3.map { c in (a, b, c) } }
-}
-
-@available(*, unavailable, renamed: "Eventually.join")
-public func join<A, B, C, D>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>) -> Eventual<(A, B, C, D)> {
-    return Eventually.join(e1, e2, e3).flatMap { (a: A, b: B, c: C) in e4.map { d in (a, b, c, d) } }
-}
-
-@available(*, unavailable, renamed: "Eventually.join")
-public func join<A, B, C, D, E>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>, _ e5: Eventual<E>) -> Eventual<(A, B, C, D, E)> {
-    return Eventually.join(e1, e2, e3, e4).flatMap { (a: A, b: B, c: C, d: D) in e5.map { e in (a, b, c, d, e) } }
-}
-
-
 // MARK: lift
 
 extension Eventually {
@@ -186,22 +159,6 @@ extension Eventually {
             join(eA, eB, eC).map(f)
         }
     }
-}
-
-// MARK: renamed Swift 2.3 'lift' functions
-@available(*, unavailable, renamed: "Eventually.lift")
-public func lift<A,B>(_ f: @escaping (A) -> B) -> ((Eventual<A>) -> Eventual<B>) {
-    return { (eA: Eventual<A>) in eA.map(f) }
-}
-
-@available(*, unavailable, renamed: "Eventually.lift")
-public func lift<A,B,C>(_ f: @escaping (A, B) -> C) -> ((Eventual<A>, Eventual<B>) -> Eventual<C>) {
-    return { (eA: Eventual<A>, eB: Eventual<B>) in Eventually.join(eA, eB).map(f) }
-}
-
-@available(*, unavailable, renamed: "Eventually.lift")
-public func lift<A,B,C,D>(_ f: @escaping (A, B, C) -> D) -> ((Eventual<A>, Eventual<B>, Eventual<C>) -> Eventual<D>) {
-    return { (eA: Eventual<A>, eB: Eventual<B>, eC: Eventual<C>) in Eventually.join(eA, eB, eC).map(f) }
 }
 
 // MARK: operators

--- a/Eventual/Eventual.swift
+++ b/Eventual/Eventual.swift
@@ -91,6 +91,11 @@ extension Eventual {
             return r.eventual.map { _ in t }
         }
     }
+
+    @available(*, unavailable, renamed: "delayed(by:)")
+    public func delayedBy(_ seconds: Double) -> Eventual<T> {
+        return delayed(by: seconds)
+    }
 }
 
 // MARK: - Resolver

--- a/Eventual/Eventual.swift
+++ b/Eventual/Eventual.swift
@@ -144,6 +144,28 @@ extension Eventually {
     }
 }
 
+// MARK: renamed Swift 2.3 'join' functions
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B>(_ e1: Eventual<A>, _ e2: Eventual<B>) -> Eventual<(A, B)> {
+    return e1.flatMap { a in e2.map { b in (a,b) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>) -> Eventual<(A, B, C)> {
+    return Eventually.join(e1, e2).flatMap { (a: A, b: B) in e3.map { c in (a, b, c) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>) -> Eventual<(A, B, C, D)> {
+    return Eventually.join(e1, e2, e3).flatMap { (a: A, b: B, c: C) in e4.map { d in (a, b, c, d) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D, E>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>, _ e5: Eventual<E>) -> Eventual<(A, B, C, D, E)> {
+    return Eventually.join(e1, e2, e3, e4).flatMap { (a: A, b: B, c: C, d: D) in e5.map { e in (a, b, c, d, e) } }
+}
+
+
 // MARK: lift
 
 extension Eventually {
@@ -164,6 +186,22 @@ extension Eventually {
             join(eA, eB, eC).map(f)
         }
     }
+}
+
+// MARK: renamed Swift 2.3 'lift' functions
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B>(_ f: @escaping (A) -> B) -> ((Eventual<A>) -> Eventual<B>) {
+    return { (eA: Eventual<A>) in eA.map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C>(_ f: @escaping (A, B) -> C) -> ((Eventual<A>, Eventual<B>) -> Eventual<C>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>) in Eventually.join(eA, eB).map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C,D>(_ f: @escaping (A, B, C) -> D) -> ((Eventual<A>, Eventual<B>, Eventual<C>) -> Eventual<D>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>, eC: Eventual<C>) in Eventually.join(eA, eB, eC).map(f) }
 }
 
 // MARK: operators

--- a/Eventual/RenamedForSwift3.swift
+++ b/Eventual/RenamedForSwift3.swift
@@ -1,0 +1,48 @@
+// The method and functions in this file were renamed so as
+// to be more in line with Swift 3 API guidelines.
+//
+// https://swift.org/documentation/api-design-guidelines/
+
+extension Eventual {
+    @available(*, unavailable, renamed: "delayed(by:)")
+    public func delayedBy(_ seconds: Double) -> Eventual<T> {
+        return delayed(by: seconds)
+    }
+}
+
+// MARK: join
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B>(_ e1: Eventual<A>, _ e2: Eventual<B>) -> Eventual<(A, B)> {
+    return e1.flatMap { a in e2.map { b in (a,b) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>) -> Eventual<(A, B, C)> {
+    return Eventually.join(e1, e2).flatMap { (a: A, b: B) in e3.map { c in (a, b, c) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>) -> Eventual<(A, B, C, D)> {
+    return Eventually.join(e1, e2, e3).flatMap { (a: A, b: B, c: C) in e4.map { d in (a, b, c, d) } }
+}
+
+@available(*, unavailable, renamed: "Eventually.join")
+public func join<A, B, C, D, E>(_ e1: Eventual<A>, _ e2: Eventual<B>, _ e3: Eventual<C>, _ e4: Eventual<D>, _ e5: Eventual<E>) -> Eventual<(A, B, C, D, E)> {
+    return Eventually.join(e1, e2, e3, e4).flatMap { (a: A, b: B, c: C, d: D) in e5.map { e in (a, b, c, d, e) } }
+}
+
+// MARK: lift
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B>(_ f: @escaping (A) -> B) -> ((Eventual<A>) -> Eventual<B>) {
+    return { (eA: Eventual<A>) in eA.map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C>(_ f: @escaping (A, B) -> C) -> ((Eventual<A>, Eventual<B>) -> Eventual<C>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>) in Eventually.join(eA, eB).map(f) }
+}
+
+@available(*, unavailable, renamed: "Eventually.lift")
+public func lift<A,B,C,D>(_ f: @escaping (A, B, C) -> D) -> ((Eventual<A>, Eventual<B>, Eventual<C>) -> Eventual<D>) {
+    return { (eA: Eventual<A>, eB: Eventual<B>, eC: Eventual<C>) in Eventually.join(eA, eB, eC).map(f) }
+}


### PR DESCRIPTION
A `renamed` annotation aids migration, and even allows Xcode to provide a FixIt.

Implementing them in terms of their new counterparts allows them to still work if the annotations are removed.
